### PR TITLE
Twitter url duct tape fix

### DIFF
--- a/src/main/java/com/alchemist/VxTweet.java
+++ b/src/main/java/com/alchemist/VxTweet.java
@@ -25,6 +25,10 @@ public record VxTweet(
     return String.format("https://twitter.com/%s/status/%s", userScreenName, tweetId);
   }
 
+  public String getVxTwitterUrl() {
+    return String.format("https://vxtwitter.com/%s/status/%s\n", userScreenName, tweetId);
+  }
+
   public String getTweetAuthorUrl() {
     return String.format("https://twitter.com/%s", userScreenName);
   }

--- a/src/main/java/com/alchemist/service/TwitterUrlReplaceListener.java
+++ b/src/main/java/com/alchemist/service/TwitterUrlReplaceListener.java
@@ -41,14 +41,14 @@ public class TwitterUrlReplaceListener extends ListenerAdapter implements Servic
 
     String msg = message.getContentDisplay();
     Matcher matcher = PATTERN.matcher(msg);
-    ArrayList<MessageEmbed> tweets = new ArrayList<MessageEmbed>();
+    ArrayList<String> tweets = new ArrayList<String>();
 
     try {
       while (matcher.find()) {
         String twitterUrl = msg.substring(matcher.start(), matcher.end());
         twitterUrl = twitterUrl.replace("twitter.com", "api.vxtwitter.com");
         twitterUrl = twitterUrl.replace("x.com", "api.vxtwitter.com");
-        tweets.add(api.getTweet(twitterUrl).toMessageEmbed());
+        tweets.add(api.getTweet(twitterUrl).getVxTwitterUrl());
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -62,8 +62,10 @@ public class TwitterUrlReplaceListener extends ListenerAdapter implements Servic
         logger.error("Cannot remove message embed. " + e.getMessage());
       }
 
-      MessageCreateBuilder builder = new MessageCreateBuilder()
-          .addEmbeds(tweets);
+      MessageCreateBuilder builder = new MessageCreateBuilder();
+      for (String tweet : tweets) {
+        builder.addContent(tweet);
+      }
 
       message
           .reply(builder.build())


### PR DESCRIPTION
## Description 

JDA does not support embedding videos in discord embed messages. 
This PR replaces the current url replacement to embed message with simple vxtwitter urls (Therefore a duct tape kinda fix).

<img width="770" height="792" alt="image" src="https://github.com/user-attachments/assets/201cab4d-5544-4821-9d2f-b84eb651581e" />
 